### PR TITLE
Cast max age to integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## UNRELEASED
+
+### Fixed
+
+- Cast max age header to integer in order to get valid expiration value.
 
 ## 1.0.0 - 2016-05-05
 

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -174,7 +174,7 @@ final class CachePlugin implements Plugin
                 return $maxAge - ((int) $age);
             }
 
-            return $maxAge;
+            return (int) $maxAge;
         }
 
         // check for ttl in the Expires header


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Related tickets | ~ |
| Documentation | ~ |
| License | MIT |

Hey!
#### What's in this PR?

This PR fixes an issue in the max age calculation. Basically, the PSR-7 implementations returns a string as header value whereas the max age should be an integer.
#### Why?

Since PHP is able to implicitely convert string to integer on the fly, it should not be an issue but when using with a PSR-6 provider such the Symfony one, adapters requires an integer as ttl otherwise it throws an exception (see [here](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Cache/CacheItem.php#L86-L94) fox example).
