### PR TITLE
Added support for Last-Modified and ETag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,11 @@
             "Http\\Client\\Common\\Plugin\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "spec\\Http\\Client\\Common\\Plugin\\": "spec/"
+        }
+    },
     "scripts": {
         "test": "vendor/bin/phpspec run",
         "test-ci": "vendor/bin/phpspec run -c phpspec.ci.yml"

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -49,13 +49,13 @@ class CachePluginSpec extends ObjectBehavior
         $item->isHit()->willReturn(false);
         $item->expiresAfter(1060)->willReturn($item)->shouldBeCalled();
 
-        $item->set(Argument::that($this->getCacheItemMatcher([
+        $item->set($this->getCacheItemMatcher([
             'response' => $response->getWrappedObject(),
             'body' => $httpBody,
             'expiresAt' => 0,
             'createdAt' => 0,
             'etag' => []
-        ])))->willReturn($item)->shouldBeCalled();
+        ]))->willReturn($item)->shouldBeCalled();
         $pool->save(Argument::any())->shouldBeCalled();
 
         $next = function (RequestInterface $request) use ($response) {
@@ -115,13 +115,13 @@ class CachePluginSpec extends ObjectBehavior
         $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
 
-        $item->set(Argument::that($this->getCacheItemMatcher([
+        $item->set($this->getCacheItemMatcher([
                 'response' => $response->getWrappedObject(),
                 'body' => $httpBody,
                 'expiresAt' => 0,
                 'createdAt' => 0,
                 'etag' => []
-            ])))->willReturn($item)->shouldBeCalled();
+            ]))->willReturn($item)->shouldBeCalled();
         // 40-15 should be 25 + the default 1000
         $item->expiresAfter(1025)->willReturn($item)->shouldBeCalled();
         $pool->save($item)->shouldBeCalled();
@@ -133,9 +133,17 @@ class CachePluginSpec extends ObjectBehavior
         $this->handleRequest($request, $next, function () {});
     }
 
+
+    /**
+     * Private function to match requests
+     *
+     * @param array $expectedData
+     *
+     * @return \Closure
+     */
     private function getCacheItemMatcher(array $expectedData)
     {
-        return function(array $actualData) use ($expectedData) {
+        return Argument::that(function(array $actualData) use ($expectedData) {
             foreach ($expectedData as $key => $value) {
                 if (!isset($actualData[$key])) {
                     return false;
@@ -151,6 +159,6 @@ class CachePluginSpec extends ObjectBehavior
                 }
             }
             return true;
-        };
+        });
     }
 }

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -16,7 +16,10 @@ class CachePluginSpec extends ObjectBehavior
 {
     function let(CacheItemPoolInterface $pool, StreamFactory $streamFactory)
     {
-        $this->beConstructedWith($pool, $streamFactory, ['default_ttl'=>60, 'cache_lifetime'=>1000]);
+        $this->beConstructedWith($pool, $streamFactory, [
+            'default_ttl' => 60,
+            'cache_lifetime'=>1000
+        ]);
     }
 
     function it_is_initializable(CacheItemPoolInterface $pool)

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -147,7 +147,7 @@ class CachePluginSpec extends ObjectBehavior
         $response->getHeader('Expires')->willReturn(array());
         $response->getHeader('ETag')->willReturn(array('foo_etag'));
 
-        $pool->getItem('e3b717d5883a45ef9493d009741f7c64')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
         $item->expiresAfter(1060)->willReturn($item);
 
@@ -179,7 +179,7 @@ class CachePluginSpec extends ObjectBehavior
 
         $response->getStatusCode()->willReturn(304);
 
-        $pool->getItem('e3b717d5883a45ef9493d009741f7c64')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(true, false);
         $item->get()->willReturn([
             'response' => $response,
@@ -203,7 +203,7 @@ class CachePluginSpec extends ObjectBehavior
         $request->getMethod()->willReturn('GET');
         $request->getUri()->willReturn('/');
 
-        $pool->getItem('e3b717d5883a45ef9493d009741f7c64')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(true);
         $item->get()->willReturn([
             'response' => $response,
@@ -241,7 +241,7 @@ class CachePluginSpec extends ObjectBehavior
         // Make sure we add back the body
         $response->withBody($stream)->willReturn($response)->shouldBeCalled();
 
-        $pool->getItem('e3b717d5883a45ef9493d009741f7c64')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(true, true);
         $item->expiresAfter(1060)->willReturn($item)->shouldBeCalled();
         $item->get()->willReturn([

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Prophecy\Argument;
+use Prophecy\Comparator\Factory as ComparatorFactory;
 use Http\Message\StreamFactory;
 use Http\Promise\FulfilledPromise;
 use PhpSpec\ObjectBehavior;
@@ -39,27 +41,28 @@ class CachePluginSpec extends ObjectBehavior
         $request->getUri()->willReturn('/');
         $response->getStatusCode()->willReturn(200);
         $response->getBody()->willReturn($stream);
-        $response->getHeader('Cache-Control')->willReturn(array());
-        $response->getHeader('Expires')->willReturn(array());
-        $response->getHeader('ETag')->willReturn(array());
+        $response->getHeader('Cache-Control')->willReturn(array())->shouldBeCalled();
+        $response->getHeader('Expires')->willReturn(array())->shouldBeCalled();
+        $response->getHeader('ETag')->willReturn(array())->shouldBeCalled();
 
         $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
-        $item->set()->willReturn($item)->shouldBeCalled();
         $item->expiresAfter(1060)->willReturn($item)->shouldBeCalled();
-        $pool->save($item)->shouldBeCalled();
+
+        $item->set(Argument::that($this->getCacheItemMatcher([
+            'response' => $response->getWrappedObject(),
+            'body' => $httpBody,
+            'expiresAt' => 0,
+            'createdAt' => 0,
+            'etag' => []
+        ])))->willReturn($item)->shouldBeCalled();
+        $pool->save(Argument::any())->shouldBeCalled();
 
         $next = function (RequestInterface $request) use ($response) {
             return new FulfilledPromise($response->getWrappedObject());
         };
 
         $this->handleRequest($request, $next, function () {});
-        $item->get()->shouldHaveKeyWithValue('response', $response);
-        $item->get()->shouldHaveKeyWithValue('body', $httpBody);
-        $item->get()->shouldHaveKey('expiresAt');
-        $item->get()->shouldHaveKey('createdAt');
-        $item->get()->shouldHaveKey('etag');
-
     }
 
     function it_doesnt_store_failed_responses(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, ResponseInterface $response)
@@ -107,13 +110,20 @@ class CachePluginSpec extends ObjectBehavior
         $response->getHeader('Cache-Control')->willReturn(array('max-age=40'));
         $response->getHeader('Age')->willReturn(array('15'));
         $response->getHeader('Expires')->willReturn(array());
+        $response->getHeader('ETag')->willReturn(array());
 
         $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
 
-        // 40-15 should be 25
-        $item->set(['response' => $response, 'body' => $httpBody])->willReturn($item)->shouldBeCalled();
-        $item->expiresAfter(25)->willReturn($item)->shouldBeCalled();
+        $item->set(Argument::that($this->getCacheItemMatcher([
+                'response' => $response->getWrappedObject(),
+                'body' => $httpBody,
+                'expiresAt' => 0,
+                'createdAt' => 0,
+                'etag' => []
+            ])))->willReturn($item)->shouldBeCalled();
+        // 40-15 should be 25 + the default 1000
+        $item->expiresAfter(1025)->willReturn($item)->shouldBeCalled();
         $pool->save($item)->shouldBeCalled();
 
         $next = function (RequestInterface $request) use ($response) {
@@ -121,5 +131,26 @@ class CachePluginSpec extends ObjectBehavior
         };
 
         $this->handleRequest($request, $next, function () {});
+    }
+
+    private function getCacheItemMatcher(array $expectedData)
+    {
+        return function(array $actualData) use ($expectedData) {
+            foreach ($expectedData as $key => $value) {
+                if (!isset($actualData[$key])) {
+                    return false;
+                }
+
+                if ($key === 'expiresAt' || $key === 'createdAt') {
+                    // We do not need to validate the value of these fields.
+                    continue;
+                }
+
+                if ($actualData[$key] !== $value) {
+                    return false;
+                }
+            }
+            return true;
+        };
     }
 }

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -18,7 +18,7 @@ class CachePluginSpec extends ObjectBehavior
     {
         $this->beConstructedWith($pool, $streamFactory, [
             'default_ttl' => 60,
-            'cache_lifetime'=>1000
+            'cache_lifetime' => 1000
         ]);
     }
 

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -41,7 +41,7 @@ final class CachePlugin implements Plugin
      *     @var bool $respect_cache_headers Whether to look at the cache directives or ignore them
      *     @var int $default_ttl (seconds) If we do not respect cache headers or can't calculate a good ttl, use this
      *              value
-     *     @var string $hash_algo The hashing algorithm to use when generating cache keys.
+     *     @var string $hash_algo The hashing algorithm to use when generating cache keys
      *     @var int $cache_lifetime (seconds) To support serving a previous stale response when the server answers 304
      *              we have to store the cache for a longer time that the server originally says it is valid for.
      *              We store a cache item for $cache_lifetime + max age of the response.

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -39,8 +39,12 @@ final class CachePlugin implements Plugin
      * @param array                  $config        {
      *
      *     @var bool $respect_cache_headers Whether to look at the cache directives or ignore them
-     *     @var int $default_ttl If we do not respect cache headers or can't calculate a good ttl, use this value
+     *     @var int $default_ttl (seconds) If we do not respect cache headers or can't calculate a good ttl, use this
+     *              value
      *     @var string $hash_algo The hashing algorithm to use when generating cache keys.
+     *     @var int $cache_lifetime (seconds) To support serving a previous stale response when the server answers 304
+     *              we have to store the cache for a longer time that the server originally says it is valid for.
+     *              We store a cache item for $cache_lifetime + max age of the response.
      * }
      */
     public function __construct(CacheItemPoolInterface $pool, StreamFactory $streamFactory, array $config = [])

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -76,23 +76,16 @@ final class CachePlugin implements Plugin
             }
 
             // Add headers to ask the server if this cache is still valid
-            if ($modifiedAt = $this->getModifiedAt($cacheItem)) {
-                $modifiedAt = new \DateTime('@'.$modifiedAt);
-                $modifiedAt->setTimezone(new \DateTimeZone('GMT'));
-                $request = $request->withHeader(
-                    'If-Modified-Since',
-                    sprintf('%s GMT', $modifiedAt->format('l, d-M-y H:i:s'))
-                );
+            if ($mod = $this->getModifiedAt($cacheItem)) {
+                $mod = new \DateTime('@'.$mod);
+                $mod->setTimezone(new \DateTimeZone('GMT'));
+                $request = $request->withHeader('If-Modified-Since', sprintf('%s GMT', $mod->format('l, d-M-y H:i:s')));
             }
 
             if ($etag = $this->getETag($cacheItem)) {
-                $request = $request->withHeader(
-                    'If-None-Match',
-                    $etag
-                );
+                $request = $request->withHeader('If-None-Match', $etag);
             }
         }
-
 
         return $next($request)->then(function (ResponseInterface $response) use ($cacheItem) {
             if (304 === $response->getStatusCode()) {

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -293,16 +293,16 @@ final class CachePlugin implements Plugin
             return;
         }
 
-        if (is_array($data['etag'])) {
-            foreach ($data['etag'] as $etag) {
-                if (!empty($etag)) {
-                    return $etag;
-                }
-            }
-
-            return;
+        if (!is_array($data['etag'])) {
+            return $data['etag'];
         }
 
-        return $data['etag'];
+        foreach ($data['etag'] as $etag) {
+            if (!empty($etag)) {
+                return $etag;
+            }
+        }
+
+        return;
     }
 }

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -103,8 +103,9 @@ final class CachePlugin implements Plugin
 
                 // The cached response we have is still valid
                 $data = $cacheItem->get();
-                $data['expiresAt'] = time() + $this->getMaxAge($response);
-                $cacheItem->set($data)->expiresAfter($this->config['cache_lifetime'] + $data['expiresAt']);
+                $maxAge = $this->getMaxAge($response);
+                $data['expiresAt'] = time() + $maxAge;
+                $cacheItem->set($data)->expiresAfter($this->config['cache_lifetime'] + $maxAge);
                 $this->pool->save($cacheItem);
 
                 return $this->createResponseFromCacheItem($cacheItem);
@@ -119,13 +120,13 @@ final class CachePlugin implements Plugin
                     $response = $response->withBody($this->streamFactory->createStream($body));
                 }
 
-                $expiresAt = time() + $this->getMaxAge($response);
+                $maxAge = $this->getMaxAge($response);
                 $cacheItem
-                    ->expiresAfter($this->config['cache_lifetime'] + $expiresAt)
+                    ->expiresAfter($this->config['cache_lifetime'] + $maxAge)
                     ->set([
                     'response' => $response,
                     'body' => $body,
-                    'expiresAt' => $expiresAt,
+                    'expiresAt' => time() + $maxAge,
                     'createdAt' => time(),
                     'etag' => $response->getHeader('ETag'),
                 ]);

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -90,7 +90,10 @@ final class CachePlugin implements Plugin
         return $next($request)->then(function (ResponseInterface $response) use ($cacheItem) {
             if (304 === $response->getStatusCode()) {
                 if (!$cacheItem->isHit()) {
-                    // We do not have the item in cache. We can return the cached response.
+                    /* 
+                     * We do not have the item in cache. This plugin did not add If-Modified-Since 
+                     * or If-None-Match headers. Return the response from server.
+                     */
                     return $response;
                 }
 

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -96,6 +96,11 @@ final class CachePlugin implements Plugin
 
         return $next($request)->then(function (ResponseInterface $response) use ($cacheItem) {
             if (304 === $response->getStatusCode()) {
+                if (!$cacheItem->isHit()) {
+                    // We do not have the item in cache. We can return the cached response.
+                    return $response;
+                }
+
                 // The cached response we have is still valid
                 $data = $cacheItem->get();
                 $data['expiresAt'] = time() + $this->getMaxAge($response);

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -90,8 +90,8 @@ final class CachePlugin implements Plugin
         return $next($request)->then(function (ResponseInterface $response) use ($cacheItem) {
             if (304 === $response->getStatusCode()) {
                 if (!$cacheItem->isHit()) {
-                    /* 
-                     * We do not have the item in cache. This plugin did not add If-Modified-Since 
+                    /*
+                     * We do not have the item in cache. This plugin did not add If-Modified-Since
                      * or If-None-Match headers. Return the response from server.
                      */
                     return $response;

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -119,12 +119,12 @@ final class CachePlugin implements Plugin
                 $cacheItem
                     ->expiresAfter($this->config['cache_lifetime'] + $maxAge)
                     ->set([
-                    'response' => $response,
-                    'body' => $body,
-                    'expiresAt' => $currentTime + $maxAge,
-                    'createdAt' => $currentTime,
-                    'etag' => $response->getHeader('ETag'),
-                ]);
+                        'response' => $response,
+                        'body' => $body,
+                        'expiresAt' => $currentTime + $maxAge,
+                        'createdAt' => $currentTime,
+                        'etag' => $response->getHeader('ETag'),
+                    ]);
                 $this->pool->save($cacheItem);
             }
 

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -70,7 +70,7 @@ final class CachePlugin implements Plugin
 
         if ($cacheItem->isHit()) {
             $data = $cacheItem->get();
-            if (isset($data['expiresAt']) && time() > $data['expiresAt']) {
+            if (isset($data['expiresAt']) && time() < $data['expiresAt']) {
                 // This item is still valid according to previous cache headers
                 return new FulfilledPromise($this->createResponseFromCacheItem($cacheItem));
             }

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -5,6 +5,7 @@ namespace Http\Client\Common\Plugin;
 use Http\Client\Common\Plugin;
 use Http\Message\StreamFactory;
 use Http\Promise\FulfilledPromise;
+use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -58,7 +59,6 @@ final class CachePlugin implements Plugin
     public function handleRequest(RequestInterface $request, callable $next, callable $first)
     {
         $method = strtoupper($request->getMethod());
-
         // if the request not is cachable, move to $next
         if ($method !== 'GET' && $method !== 'HEAD') {
             return $next($request);
@@ -69,15 +69,42 @@ final class CachePlugin implements Plugin
         $cacheItem = $this->pool->getItem($key);
 
         if ($cacheItem->isHit()) {
-            // return cached response
             $data = $cacheItem->get();
-            $response = $data['response'];
-            $response = $response->withBody($this->streamFactory->createStream($data['body']));
+            if (isset($data['expiresAt']) && time() > $data['expiresAt']) {
+                // This item is still valid according to previous cache headers
+                return new FulfilledPromise($this->createResponseFromCacheItem($cacheItem));
+            }
 
-            return new FulfilledPromise($response);
+            // Add headers to ask the server if this cache is still valid
+            if ($modifiedAt = $this->getModifiedAt($cacheItem)) {
+                $modifiedAt = new \DateTime('@'.$modifiedAt);
+                $modifiedAt->setTimezone(new \DateTimeZone('GMT'));
+                $request = $request->withHeader(
+                    'If-Modified-Since',
+                    sprintf('%s GMT', $modifiedAt->format('l, d-M-y H:i:s'))
+                );
+            }
+
+            if ($etag = $this->getETag($cacheItem)) {
+                $request = $request->withHeader(
+                    'If-None-Match',
+                    $etag
+                );
+            }
         }
 
+
         return $next($request)->then(function (ResponseInterface $response) use ($cacheItem) {
+            if (304 === $response->getStatusCode()) {
+                // The cached response we have is still valid
+                $data = $cacheItem->get();
+                $data['expiresAt'] = time() + $this->getMaxAge($response);
+                $cacheItem->set($data)->expiresAfter($this->config['cache_lifetime']);
+                $this->pool->save($cacheItem);
+
+                return $this->createResponseFromCacheItem($cacheItem);
+            }
+
             if ($this->isCacheable($response)) {
                 $bodyStream = $response->getBody();
                 $body = $bodyStream->__toString();
@@ -87,8 +114,15 @@ final class CachePlugin implements Plugin
                     $response = $response->withBody($this->streamFactory->createStream($body));
                 }
 
-                $cacheItem->set(['response' => $response, 'body' => $body])
-                    ->expiresAfter($this->getMaxAge($response));
+                $cacheItem
+                    ->expiresAfter($this->config['cache_lifetime'])
+                    ->set([
+                    'response' => $response,
+                    'body' => $body,
+                    'expiresAt' => time() + $this->getMaxAge($response),
+                    'createdAt' => time(),
+                    'etag' => $response->getHeader('ETag'),
+                ]);
                 $this->pool->save($cacheItem);
             }
 
@@ -195,13 +229,75 @@ final class CachePlugin implements Plugin
     private function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
+            'cache_lifetime' => 2592000, // 30 days
             'default_ttl' => null,
             'respect_cache_headers' => true,
             'hash_algo' => 'sha1',
         ]);
 
+        $resolver->setAllowedTypes('cache_lifetime', 'int');
         $resolver->setAllowedTypes('default_ttl', ['int', 'null']);
         $resolver->setAllowedTypes('respect_cache_headers', 'bool');
         $resolver->setAllowedValues('hash_algo', hash_algos());
+    }
+
+    /**
+     * @param CacheItemInterface $cacheItem
+     *
+     * @return ResponseInterface
+     */
+    private function createResponseFromCacheItem(CacheItemInterface $cacheItem)
+    {
+        $data = $cacheItem->get();
+
+        /** @var ResponseInterface $response */
+        $response = $data['response'];
+        $response = $response->withBody($this->streamFactory->createStream($data['body']));
+
+        return $response;
+    }
+
+    /**
+     * Get the timestamp when the cached response was stored.
+     *
+     * @param CacheItemInterface $cacheItem
+     *
+     * @return int|null
+     */
+    private function getModifiedAt(CacheItemInterface $cacheItem)
+    {
+        $data = $cacheItem->get();
+        if (!isset($data['createdAt'])) {
+            return null;
+        }
+
+        return $data['createdAt'];
+    }
+
+    /**
+     * Get the ETag from the cached response.
+     *
+     * @param CacheItemInterface $cacheItem
+     *
+     * @return string|null
+     */
+    private function getETag(CacheItemInterface $cacheItem)
+    {
+        $data = $cacheItem->get();
+        if (!isset($data['etag'])) {
+            return null;
+        }
+
+        if (is_array($data['etag'])) {
+            foreach($data['etag'] as $etag) {
+                if (!empty($etag)) {
+                    return $etag;
+                }
+            }
+
+            return null;
+        }
+
+        return $data['etag'];
     }
 }

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -302,7 +302,5 @@ final class CachePlugin implements Plugin
                 return $etag;
             }
         }
-
-        return;
     }
 }

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -74,6 +74,7 @@ final class CachePlugin implements Plugin
 
         if ($cacheItem->isHit()) {
             $data = $cacheItem->get();
+            // The isset() is to be removed in 2.0.
             if (isset($data['expiresAt']) && time() < $data['expiresAt']) {
                 // This item is still valid according to previous cache headers
                 return new FulfilledPromise($this->createResponseFromCacheItem($cacheItem));
@@ -273,6 +274,7 @@ final class CachePlugin implements Plugin
     private function getModifiedSinceHeaderValue(CacheItemInterface $cacheItem)
     {
         $data = $cacheItem->get();
+        // The isset() is to be removed in 2.0.
         if (!isset($data['createdAt'])) {
             return;
         }
@@ -293,6 +295,7 @@ final class CachePlugin implements Plugin
     private function getETag(CacheItemInterface $cacheItem)
     {
         $data = $cacheItem->get();
+        // The isset() is to be removed in 2.0.
         if (!isset($data['etag'])) {
             return;
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Related tickets | fixes #2 |
| Documentation |  |
| License | MIT |
#### What's in this PR?

We should allow the server to answer 304 which allows us to use a response in the cache. 
The BC break here is that all existing items in the cache will be invalid. Is that an issue? It is a **cache** and not a **storage**. 

I introduced a new config parameter `cache_lifetime` that says how long the item should be in cache without it being used. 

I did also add a few parameters to the array we store in the cache such as `expiresAt`, `createdAt`, `etag`. 
#### To Do
- [x] Fix the tests
