### PR TITLE
The max age must be an integer

### DIFF
--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -77,7 +77,7 @@ final class CachePlugin implements Plugin
         }
 
         return $next($request)->then(function (ResponseInterface $response) use ($cacheItem) {
-            if ($this->isCacheable($response)) {
+            if ($this->isCacheable($response) && ($maxAge = $this->getMaxAge($response)) > 0) {
                 $bodyStream = $response->getBody();
                 $body = $bodyStream->__toString();
                 if ($bodyStream->isSeekable()) {
@@ -87,7 +87,7 @@ final class CachePlugin implements Plugin
                 }
 
                 $cacheItem->set(['response' => $response, 'body' => $body])
-                    ->expiresAfter($this->getMaxAge($response));
+                    ->expiresAfter($maxAge);
                 $this->pool->save($cacheItem);
             }
 

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -163,7 +163,7 @@ final class CachePlugin implements Plugin
     private function getMaxAge(ResponseInterface $response)
     {
         if (!$this->config['respect_cache_headers']) {
-            return $this->config['default_ttl'];
+            return (int) $this->config['default_ttl'];
         }
 
         // check for max age in the Cache-Control header
@@ -171,7 +171,7 @@ final class CachePlugin implements Plugin
         if (!is_bool($maxAge)) {
             $ageHeaders = $response->getHeader('Age');
             foreach ($ageHeaders as $age) {
-                return $maxAge - ((int) $age);
+                return ((int) $maxAge) - ((int) $age);
             }
 
             return (int) $maxAge;
@@ -183,7 +183,7 @@ final class CachePlugin implements Plugin
             return (new \DateTime($header))->getTimestamp() - (new \DateTime())->getTimestamp();
         }
 
-        return $this->config['default_ttl'];
+        return (int) $this->config['default_ttl'];
     }
 
     /**

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -158,7 +158,7 @@ final class CachePlugin implements Plugin
      *
      * @param ResponseInterface $response
      *
-     * @return int|null
+     * @return int
      */
     private function getMaxAge(ResponseInterface $response)
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Related tickets | partially #5 |
| License | MIT |
#### What's in this PR?

This method must not return `null` ever since the psr cache interface does not allow null as a cache age.
#### Why?

After having issues, I created https://github.com/madewithlove/illuminate-psr-cache-bridge/issues/1, then after investigation, I came here, and found https://github.com/php-http/cache-plugin/pull/5 which appears to fix this, but the phpdoc was left unchanged, so needs correcting to avoid confusion or future breaks.
#### Checklist
- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)
