### PR TITLE
Use sha1 to reduce the risk of collisions

### DIFF
--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -42,7 +42,7 @@ class CachePluginSpec extends ObjectBehavior
         $response->getHeader('Cache-Control')->willReturn(array());
         $response->getHeader('Expires')->willReturn(array());
 
-        $pool->getItem('e3b717d5883a45ef9493d009741f7c64')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
         $item->set(['response' => $response, 'body' => $httpBody])->willReturn($item)->shouldBeCalled();
         $item->expiresAfter(60)->willReturn($item)->shouldBeCalled();
@@ -63,7 +63,7 @@ class CachePluginSpec extends ObjectBehavior
         $response->getHeader('Cache-Control')->willReturn(array());
         $response->getHeader('Expires')->willReturn(array());
 
-        $pool->getItem('e3b717d5883a45ef9493d009741f7c64')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
 
         $next = function (RequestInterface $request) use ($response) {
@@ -101,7 +101,7 @@ class CachePluginSpec extends ObjectBehavior
         $response->getHeader('Age')->willReturn(array('15'));
         $response->getHeader('Expires')->willReturn(array());
 
-        $pool->getItem('e3b717d5883a45ef9493d009741f7c64')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
 
         // 40-15 should be 25

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -77,7 +77,7 @@ final class CachePlugin implements Plugin
         }
 
         return $next($request)->then(function (ResponseInterface $response) use ($cacheItem) {
-            if ($this->isCacheable($response)) {
+            if ($this->isCacheable($response) && ($maxAge = $this->getMaxAge($response)) > 0) {
                 $bodyStream = $response->getBody();
                 $body = $bodyStream->__toString();
                 if ($bodyStream->isSeekable()) {
@@ -87,7 +87,7 @@ final class CachePlugin implements Plugin
                 }
 
                 $cacheItem->set(['response' => $response, 'body' => $body])
-                    ->expiresAfter($this->getMaxAge($response));
+                    ->expiresAfter($maxAge);
                 $this->pool->save($cacheItem);
             }
 

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -39,6 +39,7 @@ final class CachePlugin implements Plugin
      *
      *     @var bool $respect_cache_headers Whether to look at the cache directives or ignore them
      *     @var int $default_ttl If we do not respect cache headers or can't calculate a good ttl, use this value.
+     *     @var string $hash_algo The hashing algorithm to use when generating cache keys.
      * }
      */
     public function __construct(CacheItemPoolInterface $pool, StreamFactory $streamFactory, array $config = [])
@@ -150,7 +151,7 @@ final class CachePlugin implements Plugin
      */
     private function createCacheKey(RequestInterface $request)
     {
-        return sha1($request->getMethod().' '.$request->getUri());
+        return hash($this->config['hash_algo'], $request->getMethod().' '.$request->getUri());
     }
 
     /**
@@ -196,9 +197,11 @@ final class CachePlugin implements Plugin
         $resolver->setDefaults([
             'default_ttl' => null,
             'respect_cache_headers' => true,
+            'hash_algo' => 'sha1',
         ]);
 
         $resolver->setAllowedTypes('default_ttl', ['int', 'null']);
         $resolver->setAllowedTypes('respect_cache_headers', 'bool');
+        $resolver->setAllowedValues('hash_algo', hash_algos());
     }
 }

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -78,7 +78,7 @@ final class CachePlugin implements Plugin
         }
 
         return $next($request)->then(function (ResponseInterface $response) use ($cacheItem) {
-            if ($this->isCacheable($response) && ($maxAge = $this->getMaxAge($response)) > 0) {
+            if ($this->isCacheable($response)) {
                 $bodyStream = $response->getBody();
                 $body = $bodyStream->__toString();
                 if ($bodyStream->isSeekable()) {
@@ -88,7 +88,7 @@ final class CachePlugin implements Plugin
                 }
 
                 $cacheItem->set(['response' => $response, 'body' => $body])
-                    ->expiresAfter($maxAge);
+                    ->expiresAfter($this->getMaxAge($response));
                 $this->pool->save($cacheItem);
             }
 

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -38,7 +38,7 @@ final class CachePlugin implements Plugin
      * @param array                  $config        {
      *
      *     @var bool $respect_cache_headers Whether to look at the cache directives or ignore them
-     *     @var int $default_ttl If we do not respect cache headers or can't calculate a good ttl, use this value.
+     *     @var int $default_ttl If we do not respect cache headers or can't calculate a good ttl, use this value
      *     @var string $hash_algo The hashing algorithm to use when generating cache keys.
      * }
      */

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -150,7 +150,7 @@ final class CachePlugin implements Plugin
      */
     private function createCacheKey(RequestInterface $request)
     {
-        return md5($request->getMethod().' '.$request->getUri());
+        return sha1($request->getMethod().' '.$request->getUri());
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| License | MIT |
#### What's in this PR?

Switches the key generation algorithm over to use `sha1` rather than `md5`.
#### Why?

The performance is similar, and the collision risk is lower.
#### Example Usage

![image](https://cloud.githubusercontent.com/assets/2829600/17311187/50c6a8c8-5841-11e6-81b3-55523347d8f7.png)
#### Checklist
- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)
#### To Do
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
