### PR TITLE
Allow a cache item to be stored forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## UNRELEASED
+
+### Fixed
+
+- Issue when you use `respect_cache_headers=>false` in combination with `default_ttl=>null`.
 
 ## 1.1.0 - 2016-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## UNRELEASED
 
+### Changed
+
+- The default value for ``default_ttl`` is changed from ``null`` to ``0``. 
+
 ### Fixed
 
 - Issue when you use `respect_cache_headers=>false` in combination with `default_ttl=>null`.
+- We allow ``cache_lifetime`` to be set to ``null``.
 
 ## 1.1.0 - 2016-08-04
 

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -159,7 +159,7 @@ final class CachePlugin implements Plugin
      *
      * @param int|null $maxAge
      *
-     * @return int|null Unix system time
+     * @return int|null Unix system time. A null value means that the response expires when the cache item expires.
      */
     private function calculateResponseExpiresAt($maxAge)
     {

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -155,7 +155,7 @@ final class CachePlugin implements Plugin
 
     /**
      * Calculate the timestamp when a response expires. After that timestamp, we need to send a
-     * If-Modified-Since / If-None-Match request to validate the response
+     * If-Modified-Since / If-None-Match request to validate the response.
      *
      * @param int|null $maxAge
      *

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -144,7 +144,7 @@ final class CachePlugin implements Plugin
     private function calculateCacheItemExpiresAfter($maxAge)
     {
         if ($this->config['cache_lifetime'] === null && $maxAge === null) {
-            return null;
+            return;
         }
 
         return $this->config['cache_lifetime'] + $maxAge;
@@ -157,11 +157,11 @@ final class CachePlugin implements Plugin
      */
     private function getResponseExpiresAt($maxAge)
     {
-        if ($maxAge !== null) {
-            return time() + $maxAge;
+        if ($maxAge === null) {
+            return;
         }
 
-        return null;
+        return time() + $maxAge;
     }
 
     /**

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -159,7 +159,7 @@ final class CachePlugin implements Plugin
      *
      * @param int|null $maxAge
      *
-     * @return int|null Unix system time. A null value means that the response expires when the cache item expires.
+     * @return int|null Unix system time. A null value means that the response expires when the cache item expires
      */
     private function calculateResponseExpiresAt($maxAge)
     {

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -142,7 +142,7 @@ final class CachePlugin implements Plugin
      *
      * @param int|null $maxAge
      *
-     * @return int|null Unix system time
+     * @return int|null Unix system time. @see PSR6 for caching
      */
     private function calculateCacheItemExpiresAfter($maxAge)
     {
@@ -159,7 +159,7 @@ final class CachePlugin implements Plugin
      *
      * @param int|null $maxAge
      *
-     * @return int|null
+     * @return int|null Unix system time
      */
     private function calculateResponseExpiresAt($maxAge)
     {

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -142,7 +142,7 @@ final class CachePlugin implements Plugin
      *
      * @param int|null $maxAge
      *
-     * @return int|null Unix system time. @see PSR6 for caching
+     * @return int|null Unix system time passed to the PSR-6 cache
      */
     private function calculateCacheItemExpiresAfter($maxAge)
     {

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -103,7 +103,7 @@ final class CachePlugin implements Plugin
                 // The cached response we have is still valid
                 $data = $cacheItem->get();
                 $maxAge = $this->getMaxAge($response);
-                $data['expiresAt'] = $this->getResponseExpiresAt($maxAge);
+                $data['expiresAt'] = $this->calculateResponseExpiresAt($maxAge);
                 $cacheItem->set($data)->expiresAfter($this->calculateCacheItemExpiresAfter($maxAge));
                 $this->pool->save($cacheItem);
 
@@ -125,7 +125,7 @@ final class CachePlugin implements Plugin
                     ->set([
                         'response' => $response,
                         'body' => $body,
-                        'expiresAt' => $this->getResponseExpiresAt($maxAge),
+                        'expiresAt' => $this->calculateResponseExpiresAt($maxAge),
                         'createdAt' => time(),
                         'etag' => $response->getHeader('ETag'),
                     ]);
@@ -155,7 +155,7 @@ final class CachePlugin implements Plugin
      *
      * @return int|null
      */
-    private function getResponseExpiresAt($maxAge)
+    private function calculateResponseExpiresAt($maxAge)
     {
         if ($maxAge === null) {
             return;

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -264,12 +264,12 @@ final class CachePlugin implements Plugin
     {
         $resolver->setDefaults([
             'cache_lifetime' => 86400 * 30, // 30 days
-            'default_ttl' => null,
+            'default_ttl' => 0,
             'respect_cache_headers' => true,
             'hash_algo' => 'sha1',
         ]);
 
-        $resolver->setAllowedTypes('cache_lifetime', 'int');
+        $resolver->setAllowedTypes('cache_lifetime', ['int', 'null']);
         $resolver->setAllowedTypes('default_ttl', ['int', 'null']);
         $resolver->setAllowedTypes('respect_cache_headers', 'bool');
         $resolver->setAllowedValues('hash_algo', hash_algos());

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -137,9 +137,12 @@ final class CachePlugin implements Plugin
     }
 
     /**
+     * Calculate the timestamp when this cache item should be dropped from the cache. The lowest value return after
+     * the calculation is $maxAge.
+     *
      * @param int|null $maxAge
      *
-     * @return int|null
+     * @return int|null Unix system time
      */
     private function calculateCacheItemExpiresAfter($maxAge)
     {
@@ -151,6 +154,9 @@ final class CachePlugin implements Plugin
     }
 
     /**
+     * Calculate the timestamp when a response expires. After that timestamp, we need to send a
+     * If-Modified-Since / If-None-Match request to validate the response
+     *
      * @param int|null $maxAge
      *
      * @return int|null

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -137,8 +137,8 @@ final class CachePlugin implements Plugin
     }
 
     /**
-     * Calculate the timestamp when this cache item should be dropped from the cache. The lowest value return after
-     * the calculation is $maxAge.
+     * Calculate the timestamp when this cache item should be dropped from the cache. The lowest value that can be
+     * returned is $maxAge.
      *
      * @param int|null $maxAge
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Related tickets | fixes #19 |
| Documentation | https://github.com/php-http/documentation/pull/144 |
| License | MIT |
#### What's in this PR?

If you configure your `default_ttl` to be null you should store (and be valid) the response as long as the cache item is stored. 

Also, if you configure `cache_lifetime` to be null you should store the cache item forever. 
#### Why?

At the moment we calculate the `expiresAt` as `$maxAge + time()` which is just `time()` when $maxAge is null. This is why we got issues like #19.
