### PR TITLE
Optionally enable caching of any request method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Change Log
 
+## 1.3.0 - unreleased
+### Added
+
+- New `methods` setting which allows to configure the request methods which can be cached.
 
 ## 1.2.0 - 2016-08-16
 
 ### Changed
 
-- The default value for `default_ttl` is changed from `null` to `0`. 
+- The default value for `default_ttl` is changed from `null` to `0`.
 
 ### Fixed
 

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -97,8 +97,14 @@ class CachePluginSpec extends ObjectBehavior
         $this->handleRequest($request, $next, function () {});
     }
 
-    function it_stores_post_requests_when_allowed(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, ResponseInterface $response, StreamFactory $streamFactory, StreamInterface $stream)
-    {
+    function it_stores_post_requests_when_allowed(
+        CacheItemPoolInterface $pool,
+        CacheItemInterface $item,
+        RequestInterface $request,
+        ResponseInterface $response,
+        StreamFactory $streamFactory,
+        StreamInterface $stream
+    ) {
         $this->beConstructedWith($pool, $streamFactory, [
             'default_ttl' => 60,
             'cache_lifetime' => 1000,
@@ -116,9 +122,9 @@ class CachePluginSpec extends ObjectBehavior
 
         $response->getStatusCode()->willReturn(200);
         $response->getBody()->willReturn($stream);
-        $response->getHeader('Cache-Control')->willReturn(array())->shouldBeCalled();
-        $response->getHeader('Expires')->willReturn(array())->shouldBeCalled();
-        $response->getHeader('ETag')->willReturn(array())->shouldBeCalled();
+        $response->getHeader('Cache-Control')->willReturn([])->shouldBeCalled();
+        $response->getHeader('Expires')->willReturn([])->shouldBeCalled();
+        $response->getHeader('ETag')->willReturn([])->shouldBeCalled();
 
         $pool->getItem('e4311a9af932c603b400a54efab21b6d7dea7a90')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -166,6 +166,9 @@ class CachePluginSpec extends ObjectBehavior
         $this
             ->shouldThrow("Symfony\Component\OptionsResolver\Exception\InvalidOptionsException")
             ->during('__construct', [$pool, $streamFactory, ['methods' => ['GET', 'HEAD"', 'POST']]]);
+        $this
+            ->shouldThrow("Symfony\Component\OptionsResolver\Exception\InvalidOptionsException")
+            ->during('__construct', [$pool, $streamFactory, ['methods' => ['GET', 'head', 'POST']]]);
     }
 
     function it_calculate_age_from_response(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, ResponseInterface $response, StreamInterface $stream)

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -49,7 +49,7 @@ class CachePluginSpec extends ObjectBehavior
         $response->getHeader('Expires')->willReturn(array())->shouldBeCalled();
         $response->getHeader('ETag')->willReturn(array())->shouldBeCalled();
 
-        $pool->getItem('15a7c0e71475fda62536abd940c55a9d1749ce47')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
         $item->expiresAfter(1060)->willReturn($item)->shouldBeCalled();
 
@@ -79,7 +79,7 @@ class CachePluginSpec extends ObjectBehavior
         $response->getHeader('Cache-Control')->willReturn(array());
         $response->getHeader('Expires')->willReturn(array());
 
-        $pool->getItem('15a7c0e71475fda62536abd940c55a9d1749ce47')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
 
         $next = function (RequestInterface $request) use ($response) {
@@ -188,7 +188,7 @@ class CachePluginSpec extends ObjectBehavior
         $response->getHeader('Expires')->willReturn(array());
         $response->getHeader('ETag')->willReturn(array());
 
-        $pool->getItem('15a7c0e71475fda62536abd940c55a9d1749ce47')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
 
         $item->set($this->getCacheItemMatcher([
@@ -225,7 +225,7 @@ class CachePluginSpec extends ObjectBehavior
         $response->getHeader('Expires')->willReturn(array());
         $response->getHeader('ETag')->willReturn(array('foo_etag'));
 
-        $pool->getItem('15a7c0e71475fda62536abd940c55a9d1749ce47')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
         $item->expiresAfter(1060)->willReturn($item);
 
@@ -258,7 +258,7 @@ class CachePluginSpec extends ObjectBehavior
 
         $response->getStatusCode()->willReturn(304);
 
-        $pool->getItem('15a7c0e71475fda62536abd940c55a9d1749ce47')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(true, false);
         $item->get()->willReturn([
             'response' => $response,
@@ -283,7 +283,7 @@ class CachePluginSpec extends ObjectBehavior
         $request->getUri()->willReturn('/');
         $request->getBody()->shouldBeCalled();
 
-        $pool->getItem('15a7c0e71475fda62536abd940c55a9d1749ce47')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(true);
         $item->get()->willReturn([
             'response' => $response,
@@ -322,7 +322,7 @@ class CachePluginSpec extends ObjectBehavior
         // Make sure we add back the body
         $response->withBody($stream)->willReturn($response)->shouldBeCalled();
 
-        $pool->getItem('15a7c0e71475fda62536abd940c55a9d1749ce47')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(true, true);
         $item->expiresAfter(1060)->willReturn($item)->shouldBeCalled();
         $item->get()->willReturn([

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -50,7 +50,7 @@ class CachePluginSpec extends ObjectBehavior
         $response->getHeader('Expires')->willReturn(array())->shouldBeCalled();
         $response->getHeader('ETag')->willReturn(array())->shouldBeCalled();
 
-        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('15a7c0e71475fda62536abd940c55a9d1749ce47')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
         $item->expiresAfter(1060)->willReturn($item)->shouldBeCalled();
 
@@ -80,7 +80,7 @@ class CachePluginSpec extends ObjectBehavior
         $response->getHeader('Cache-Control')->willReturn(array());
         $response->getHeader('Expires')->willReturn(array());
 
-        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('15a7c0e71475fda62536abd940c55a9d1749ce47')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
 
         $next = function (RequestInterface $request) use ($response) {
@@ -131,7 +131,7 @@ class CachePluginSpec extends ObjectBehavior
         $response->getHeader('Expires')->willReturn([])->shouldBeCalled();
         $response->getHeader('ETag')->willReturn([])->shouldBeCalled();
 
-        $pool->getItem('e37195334979e7ca0dda534c48a02c7de8368d64')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('e4311a9af932c603b400a54efab21b6d7dea7a90')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
         $item->expiresAfter(1060)->willReturn($item)->shouldBeCalled();
 
@@ -189,7 +189,7 @@ class CachePluginSpec extends ObjectBehavior
         $response->getHeader('Expires')->willReturn(array());
         $response->getHeader('ETag')->willReturn(array());
 
-        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('15a7c0e71475fda62536abd940c55a9d1749ce47')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
 
         $item->set($this->getCacheItemMatcher([
@@ -226,7 +226,7 @@ class CachePluginSpec extends ObjectBehavior
         $response->getHeader('Expires')->willReturn(array());
         $response->getHeader('ETag')->willReturn(array('foo_etag'));
 
-        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('15a7c0e71475fda62536abd940c55a9d1749ce47')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
         $item->expiresAfter(1060)->willReturn($item);
 
@@ -259,7 +259,7 @@ class CachePluginSpec extends ObjectBehavior
 
         $response->getStatusCode()->willReturn(304);
 
-        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('15a7c0e71475fda62536abd940c55a9d1749ce47')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(true, false);
         $item->get()->willReturn([
             'response' => $response,
@@ -284,7 +284,7 @@ class CachePluginSpec extends ObjectBehavior
         $request->getUri()->willReturn('/');
         $request->getBody()->shouldBeCalled();
 
-        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('15a7c0e71475fda62536abd940c55a9d1749ce47')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(true);
         $item->get()->willReturn([
             'response' => $response,
@@ -323,7 +323,7 @@ class CachePluginSpec extends ObjectBehavior
         // Make sure we add back the body
         $response->withBody($stream)->willReturn($response)->shouldBeCalled();
 
-        $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('15a7c0e71475fda62536abd940c55a9d1749ce47')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(true, true);
         $item->expiresAfter(1060)->willReturn($item)->shouldBeCalled();
         $item->get()->willReturn([

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -11,7 +11,6 @@ use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
-use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 class CachePluginSpec extends ObjectBehavior
 {

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -11,6 +11,7 @@ use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 class CachePluginSpec extends ObjectBehavior
 {
@@ -145,6 +146,22 @@ class CachePluginSpec extends ObjectBehavior
         };
 
         $this->handleRequest($request, $next, function () {});
+    }
+
+    function it_does_not_allow_invalid_request_methods(
+        CacheItemPoolInterface $pool,
+        CacheItemInterface $item,
+        RequestInterface $request,
+        ResponseInterface $response,
+        StreamFactory $streamFactory,
+        StreamInterface $stream
+    ) {
+        $this
+            ->shouldThrow(InvalidOptionsException::class)
+            ->during('__construct', [$pool, $streamFactory, ['methods' => ['GET', 'HEAD', 'POST ']]]);
+        $this
+            ->shouldThrow(InvalidOptionsException::class)
+            ->during('__construct', [$pool, $streamFactory, ['methods' => ['GET', 'HEAD"', 'POST']]]);
     }
 
     function it_calculate_age_from_response(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, ResponseInterface $response, StreamInterface $stream)

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -42,6 +42,8 @@ class CachePluginSpec extends ObjectBehavior
 
         $request->getMethod()->willReturn('GET');
         $request->getUri()->willReturn('/');
+        $request->getBody()->shouldBeCalled();
+
         $response->getStatusCode()->willReturn(200);
         $response->getBody()->willReturn($stream);
         $response->getHeader('Cache-Control')->willReturn(array())->shouldBeCalled();
@@ -72,6 +74,8 @@ class CachePluginSpec extends ObjectBehavior
     {
         $request->getMethod()->willReturn('GET');
         $request->getUri()->willReturn('/');
+        $request->getBody()->shouldBeCalled();
+
         $response->getStatusCode()->willReturn(400);
         $response->getHeader('Cache-Control')->willReturn(array());
         $response->getHeader('Expires')->willReturn(array());
@@ -127,7 +131,7 @@ class CachePluginSpec extends ObjectBehavior
         $response->getHeader('Expires')->willReturn([])->shouldBeCalled();
         $response->getHeader('ETag')->willReturn([])->shouldBeCalled();
 
-        $pool->getItem('e4311a9af932c603b400a54efab21b6d7dea7a90')->shouldBeCalled()->willReturn($item);
+        $pool->getItem('e37195334979e7ca0dda534c48a02c7de8368d64')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
         $item->expiresAfter(1060)->willReturn($item)->shouldBeCalled();
 
@@ -173,6 +177,8 @@ class CachePluginSpec extends ObjectBehavior
 
         $request->getMethod()->willReturn('GET');
         $request->getUri()->willReturn('/');
+        $request->getBody()->shouldBeCalled();
+
         $response->getStatusCode()->willReturn(200);
         $response->getBody()->willReturn($stream);
         $response->getHeader('Cache-Control')->willReturn(array('max-age=40'));
@@ -207,6 +213,7 @@ class CachePluginSpec extends ObjectBehavior
         $stream->__toString()->willReturn($httpBody);
         $stream->isSeekable()->willReturn(true);
         $stream->rewind()->shouldBeCalled();
+        $request->getBody()->shouldBeCalled();
 
         $request->getMethod()->willReturn('GET');
         $request->getUri()->willReturn('/');
@@ -242,6 +249,7 @@ class CachePluginSpec extends ObjectBehavior
 
         $request->getMethod()->willReturn('GET');
         $request->getUri()->willReturn('/');
+        $request->getBody()->shouldBeCalled();
 
         $request->withHeader('If-Modified-Since', 'Thursday, 01-Jan-70 01:18:31 GMT')->shouldBeCalled()->willReturn($request);
         $request->withHeader('If-None-Match', 'foo_etag')->shouldBeCalled()->willReturn($request);
@@ -271,6 +279,7 @@ class CachePluginSpec extends ObjectBehavior
 
         $request->getMethod()->willReturn('GET');
         $request->getUri()->willReturn('/');
+        $request->getBody()->shouldBeCalled();
 
         $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(true);
@@ -299,6 +308,7 @@ class CachePluginSpec extends ObjectBehavior
 
         $request->getMethod()->willReturn('GET');
         $request->getUri()->willReturn('/');
+        $request->getBody()->shouldBeCalled();
 
         $request->withHeader(Argument::any(), Argument::any())->willReturn($request);
         $request->withHeader(Argument::any(), Argument::any())->willReturn($request);

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -161,10 +161,10 @@ class CachePluginSpec extends ObjectBehavior
         StreamInterface $stream
     ) {
         $this
-            ->shouldThrow(InvalidOptionsException::class)
+            ->shouldThrow("Symfony\Component\OptionsResolver\Exception\InvalidOptionsException")
             ->during('__construct', [$pool, $streamFactory, ['methods' => ['GET', 'HEAD', 'POST ']]]);
         $this
-            ->shouldThrow(InvalidOptionsException::class)
+            ->shouldThrow("Symfony\Component\OptionsResolver\Exception\InvalidOptionsException")
             ->during('__construct', [$pool, $streamFactory, ['methods' => ['GET', 'HEAD"', 'POST']]]);
     }
 

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -227,7 +227,7 @@ final class CachePlugin implements Plugin
     {
         $body = (string) $request->getBody();
         if (!empty($body)) {
-            $body = ' ' . $body;
+            $body = ' '.$body;
         }
 
         return hash($this->config['hash_algo'], $request->getMethod().' '.$request->getUri().$body);

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -281,6 +281,7 @@ final class CachePlugin implements Plugin
         $resolver->setAllowedTypes('methods', 'array');
         $resolver->setAllowedValues('hash_algo', hash_algos());
         $resolver->setAllowedValues('methods', function ($value) {
+            /* Any VCHAR, except delimiters. RFC7230 sections 3.1.1 and 3.2.6 */
             $matches = preg_grep('/[^[:alnum:]!#$%&\'*\/+\-.^_`|~]/', $value);
 
             return empty($matches);

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -45,7 +45,7 @@ final class CachePlugin implements Plugin
      *     @var int $cache_lifetime (seconds) To support serving a previous stale response when the server answers 304
      *              we have to store the cache for a longer time than the server originally says it is valid for.
      *              We store a cache item for $cache_lifetime + max age of the response.
-     *     @var array $methods case sensitive list of request methods which can be cached.
+     *     @var array $methods list of request methods which can be cached.
      * }
      */
     public function __construct(CacheItemPoolInterface $pool, StreamFactory $streamFactory, array $config = [])
@@ -282,8 +282,8 @@ final class CachePlugin implements Plugin
         $resolver->setAllowedTypes('methods', 'array');
         $resolver->setAllowedValues('hash_algo', hash_algos());
         $resolver->setAllowedValues('methods', function ($value) {
-            /* Any VCHAR, except delimiters. RFC7230 sections 3.1.1 and 3.2.6 */
-            $matches = preg_grep('/[^[:alnum:]!#$%&\'*\/+\-.^_`|~]/', $value);
+            /* RFC7230 sections 3.1.1 and 3.2.6 except limited to uppercase characters. */
+            $matches = preg_grep('/[^A-Z0-9!#$%&\'*\/+\-.^_`|~]/', $value);
 
             return empty($matches);
         });

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -227,7 +227,7 @@ final class CachePlugin implements Plugin
     {
         $body = (string) $request->getBody();
         if (!empty($body)) {
-          $body = ' ' . $body;
+            $body = ' ' . $body;
         }
 
         return hash($this->config['hash_algo'], $request->getMethod().' '.$request->getUri().$body);

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -205,7 +205,6 @@ final class CachePlugin implements Plugin
         $headers = $response->getHeader('Cache-Control');
         foreach ($headers as $header) {
             if (preg_match(sprintf('|%s=?([0-9]+)?|i', $name), $header, $matches)) {
-
                 // return the value for $name if it exists
                 if (isset($matches[1])) {
                     return $matches[1];
@@ -228,6 +227,7 @@ final class CachePlugin implements Plugin
         if ('POST' === $request->getMethod()) {
             return hash($this->config['hash_algo'], $request->getMethod().' '.$request->getUri().' '.$request->getBody());
         }
+
         return hash($this->config['hash_algo'], $request->getMethod().' '.$request->getUri());
     }
 

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -45,7 +45,7 @@ final class CachePlugin implements Plugin
      *     @var int $cache_lifetime (seconds) To support serving a previous stale response when the server answers 304
      *              we have to store the cache for a longer time than the server originally says it is valid for.
      *              We store a cache item for $cache_lifetime + max age of the response.
-     *     @var array $methods case insensitive list of request methods which can be cached.
+     *     @var array $methods case sensitive list of request methods which can be cached.
      * }
      */
     public function __construct(CacheItemPoolInterface $pool, StreamFactory $streamFactory, array $config = [])

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -225,7 +225,12 @@ final class CachePlugin implements Plugin
      */
     private function createCacheKey(RequestInterface $request)
     {
-        return hash($this->config['hash_algo'], $request->getMethod().' '.$request->getUri().' '.$request->getBody());
+        $body = (string) $request->getBody();
+        if (!empty($body)) {
+          $body = ' ' . $body;
+        }
+
+        return hash($this->config['hash_algo'], $request->getMethod().' '.$request->getUri().$body);
     }
 
     /**

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -224,11 +224,7 @@ final class CachePlugin implements Plugin
      */
     private function createCacheKey(RequestInterface $request)
     {
-        if ('POST' === $request->getMethod()) {
-            return hash($this->config['hash_algo'], $request->getMethod().' '.$request->getUri().' '.$request->getBody());
-        }
-
-        return hash($this->config['hash_algo'], $request->getMethod().' '.$request->getUri());
+        return hash($this->config['hash_algo'], $request->getMethod().' '.$request->getUri().$request->getBody());
     }
 
     /**

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -282,6 +282,7 @@ final class CachePlugin implements Plugin
         $resolver->setAllowedValues('hash_algo', hash_algos());
         $resolver->setAllowedValues('methods', function ($value) {
             $matches = preg_grep('/[^[:alnum:]!#$%&\'*\/+\-.^_`|~]/', $value);
+
             return empty($matches);
         });
     }

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -285,7 +285,8 @@ final class CachePlugin implements Plugin
         $resolver->setAllowedTypes('methods', 'array');
         $resolver->setAllowedValues('hash_algo', hash_algos());
         $resolver->setAllowedValues('methods', function ($value) {
-            return 0 === count(array_diff($value, ['GET', 'HEAD', 'POST']));
+            $matches = preg_grep('/[^[:alnum:]!#$%&\'*\/+\-.^_`|~]/', $value);
+            return empty($matches);
         });
     }
 

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -45,6 +45,7 @@ final class CachePlugin implements Plugin
      *     @var int $cache_lifetime (seconds) To support serving a previous stale response when the server answers 304
      *              we have to store the cache for a longer time than the server originally says it is valid for.
      *              We store a cache item for $cache_lifetime + max age of the response.
+     *     @var array $methods case insensitive list of request methods which can be cached.
      * }
      */
     public function __construct(CacheItemPoolInterface $pool, StreamFactory $streamFactory, array $config = [])

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -225,7 +225,7 @@ final class CachePlugin implements Plugin
      */
     private function createCacheKey(RequestInterface $request)
     {
-        return hash($this->config['hash_algo'], $request->getMethod().' '.$request->getUri().$request->getBody());
+        return hash($this->config['hash_algo'], $request->getMethod().' '.$request->getUri().' '.$request->getBody());
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Documentation   | https://github.com/php-http/documentation/pull/174
| License         | MIT

#### What's in this PR?

Adds  new `methods` setting which allows you to change which request methods are allowed to be cached.

#### Why?

Sometimes it is desirable to cache `POST` requests. For example when using HTTPlug based SOAP client. I am currently using this in live system for SOAP requests.

#### Example Usage

To enable caching of `GET` and `POST` requests you can do the following.

```php
$cache = new CachePlugin($pool, $streamFactory, [
    "default_ttl" => 3600 * 48,
    "respect_cache_headers" => true,
    "methods" => ["GET", "POST"]
]);
```

#### Checklist

- [x] Updated CHANGELOG.md to describe new feature.
- [x] Documentation pull request created.

#### To Do

- [x] Should PUT and PATCH et al. also be allowed if user requests so?
- [x] Make sure tests are actually ok.
