### PR TITLE
PSR-2 compliance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "require-dev": {
         "phpspec/phpspec": "^2.5",
-        "henrikbjorn/phpspec-code-coverage" : "^1.0"
+        "henrikbjorn/phpspec-code-coverage" : "^1.0",
+        "squizlabs/php_codesniffer": "^2.8"
     },
     "autoload": {
         "psr-4": {
@@ -33,7 +34,8 @@
     },
     "scripts": {
         "test": "vendor/bin/phpspec run",
-        "test-ci": "vendor/bin/phpspec run -c phpspec.ci.yml"
+        "test-ci": "vendor/bin/phpspec run -c phpspec.ci.yml",
+        "phpcs": "vendor/bin/phpcs src/* spec/*"
     },
     "extra": {
         "branch-alias": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset name="HTTPlug">
+    <description>PSR-2 without CamelCapsMethodName for tests</description>
+    <rule ref="PSR2" />
+    <rule ref="PSR1.Methods.CamelCapsMethodName">
+        <exclude-pattern>*/spec/*</exclude-pattern>
+    </rule>
+</ruleset>

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\StreamInterface;
 
 class CachePluginSpec extends ObjectBehavior
 {
-    function let(CacheItemPoolInterface $pool, StreamFactory $streamFactory)
+    public function let(CacheItemPoolInterface $pool, StreamFactory $streamFactory)
     {
         $this->beConstructedWith($pool, $streamFactory, [
             'default_ttl' => 60,
@@ -22,18 +22,23 @@ class CachePluginSpec extends ObjectBehavior
         ]);
     }
 
-    function it_is_initializable(CacheItemPoolInterface $pool)
+    public function it_is_initializable(CacheItemPoolInterface $pool)
     {
         $this->shouldHaveType('Http\Client\Common\Plugin\CachePlugin');
     }
 
-    function it_is_a_plugin()
+    public function it_is_a_plugin()
     {
         $this->shouldImplement('Http\Client\Common\Plugin');
     }
 
-    function it_caches_responses(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, ResponseInterface $response, StreamInterface $stream)
-    {
+    public function it_caches_responses(
+        CacheItemPoolInterface $pool,
+        CacheItemInterface $item,
+        RequestInterface $request,
+        ResponseInterface $response,
+        StreamInterface $stream
+    ) {
         $httpBody = 'body';
         $stream->__toString()->willReturn($httpBody);
         $stream->isSeekable()->willReturn(true);
@@ -64,11 +69,16 @@ class CachePluginSpec extends ObjectBehavior
             return new FulfilledPromise($response->getWrappedObject());
         };
 
-        $this->handleRequest($request, $next, function () {});
+        $this->handleRequest($request, $next, function () {
+        });
     }
 
-    function it_doesnt_store_failed_responses(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, ResponseInterface $response)
-    {
+    public function it_doesnt_store_failed_responses(
+        CacheItemPoolInterface $pool,
+        CacheItemInterface $item,
+        RequestInterface $request,
+        ResponseInterface $response
+    ) {
         $request->getMethod()->willReturn('GET');
         $request->getUri()->willReturn('/');
         $response->getStatusCode()->willReturn(400);
@@ -82,11 +92,16 @@ class CachePluginSpec extends ObjectBehavior
             return new FulfilledPromise($response->getWrappedObject());
         };
 
-        $this->handleRequest($request, $next, function () {});
+        $this->handleRequest($request, $next, function () {
+        });
     }
 
-    function it_doesnt_store_post_requests(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, ResponseInterface $response)
-    {
+    public function it_doesnt_store_post_requests(
+        CacheItemPoolInterface $pool,
+        CacheItemInterface $item,
+        RequestInterface $request,
+        ResponseInterface $response
+    ) {
         $request->getMethod()->willReturn('POST');
         $request->getUri()->willReturn('/');
 
@@ -94,12 +109,17 @@ class CachePluginSpec extends ObjectBehavior
             return new FulfilledPromise($response->getWrappedObject());
         };
 
-        $this->handleRequest($request, $next, function () {});
+        $this->handleRequest($request, $next, function () {
+        });
     }
 
-
-    function it_calculate_age_from_response(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, ResponseInterface $response, StreamInterface $stream)
-    {
+    public function it_calculate_age_from_response(
+        CacheItemPoolInterface $pool,
+        CacheItemInterface $item,
+        RequestInterface $request,
+        ResponseInterface $response,
+        StreamInterface $stream
+    ) {
         $httpBody = 'body';
         $stream->__toString()->willReturn($httpBody);
         $stream->isSeekable()->willReturn(true);
@@ -132,11 +152,17 @@ class CachePluginSpec extends ObjectBehavior
             return new FulfilledPromise($response->getWrappedObject());
         };
 
-        $this->handleRequest($request, $next, function () {});
+        $this->handleRequest($request, $next, function () {
+        });
     }
 
-    function it_saves_etag(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, ResponseInterface $response, StreamInterface $stream)
-    {
+    public function it_saves_etag(
+        CacheItemPoolInterface $pool,
+        CacheItemInterface $item,
+        RequestInterface $request,
+        ResponseInterface $response,
+        StreamInterface $stream
+    ) {
         $httpBody = 'body';
         $stream->__toString()->willReturn($httpBody);
         $stream->isSeekable()->willReturn(true);
@@ -167,17 +193,26 @@ class CachePluginSpec extends ObjectBehavior
             return new FulfilledPromise($response->getWrappedObject());
         };
 
-        $this->handleRequest($request, $next, function () {});
+        $this->handleRequest($request, $next, function () {
+        });
     }
 
-    function it_adds_etag_and_modfied_since_to_request(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, ResponseInterface $response, StreamInterface $stream)
-    {
+    public function it_adds_etag_and_modfied_since_to_request(
+        CacheItemPoolInterface $pool,
+        CacheItemInterface $item,
+        RequestInterface $request,
+        ResponseInterface $response,
+        StreamInterface $stream
+    ) {
         $httpBody = 'body';
 
         $request->getMethod()->willReturn('GET');
         $request->getUri()->willReturn('/');
 
-        $request->withHeader('If-Modified-Since', 'Thursday, 01-Jan-70 01:18:31 GMT')->shouldBeCalled()->willReturn($request);
+        $request
+            ->withHeader('If-Modified-Since', 'Thursday, 01-Jan-70 01:18:31 GMT')
+            ->shouldBeCalled()
+            ->willReturn($request);
         $request->withHeader('If-None-Match', 'foo_etag')->shouldBeCalled()->willReturn($request);
 
         $response->getStatusCode()->willReturn(304);
@@ -196,11 +231,18 @@ class CachePluginSpec extends ObjectBehavior
             return new FulfilledPromise($response->getWrappedObject());
         };
 
-        $this->handleRequest($request, $next, function () {});
+        $this->handleRequest($request, $next, function () {
+        });
     }
 
-    function it_servces_a_cached_response(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, ResponseInterface $response, StreamInterface $stream, StreamFactory $streamFactory)
-    {
+    public function it_servces_a_cached_response(
+        CacheItemPoolInterface $pool,
+        CacheItemInterface $item,
+        RequestInterface $request,
+        ResponseInterface $response,
+        StreamInterface $stream,
+        StreamFactory $streamFactory
+    ) {
         $httpBody = 'body';
 
         $request->getMethod()->willReturn('GET');
@@ -224,11 +266,18 @@ class CachePluginSpec extends ObjectBehavior
             return new FulfilledPromise($response->getWrappedObject());
         };
 
-        $this->handleRequest($request, $next, function () {});
+        $this->handleRequest($request, $next, function () {
+        });
     }
 
-    function it_serves_and_resaved_expired_response(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, ResponseInterface $response, StreamInterface $stream, StreamFactory $streamFactory)
-    {
+    public function it_serves_and_resaved_expired_response(
+        CacheItemPoolInterface $pool,
+        CacheItemInterface $item,
+        RequestInterface $request,
+        ResponseInterface $response,
+        StreamInterface $stream,
+        StreamFactory $streamFactory
+    ) {
         $httpBody = 'body';
 
         $request->getMethod()->willReturn('GET');
@@ -270,7 +319,8 @@ class CachePluginSpec extends ObjectBehavior
             return new FulfilledPromise($response->getWrappedObject());
         };
 
-        $this->handleRequest($request, $next, function () {});
+        $this->handleRequest($request, $next, function () {
+        });
     }
 
 
@@ -283,7 +333,7 @@ class CachePluginSpec extends ObjectBehavior
      */
     private function getCacheItemMatcher(array $expectedData)
     {
-        return Argument::that(function(array $actualData) use ($expectedData) {
+        return Argument::that(function (array $actualData) use ($expectedData) {
             foreach ($expectedData as $key => $value) {
                 if (!isset($actualData[$key])) {
                     return false;

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -48,9 +48,9 @@ class CachePluginSpec extends ObjectBehavior
         $request->getUri()->willReturn('/');
         $response->getStatusCode()->willReturn(200);
         $response->getBody()->willReturn($stream);
-        $response->getHeader('Cache-Control')->willReturn(array())->shouldBeCalled();
-        $response->getHeader('Expires')->willReturn(array())->shouldBeCalled();
-        $response->getHeader('ETag')->willReturn(array())->shouldBeCalled();
+        $response->getHeader('Cache-Control')->willReturn([])->shouldBeCalled();
+        $response->getHeader('Expires')->willReturn([])->shouldBeCalled();
+        $response->getHeader('ETag')->willReturn([])->shouldBeCalled();
 
         $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
@@ -82,8 +82,8 @@ class CachePluginSpec extends ObjectBehavior
         $request->getMethod()->willReturn('GET');
         $request->getUri()->willReturn('/');
         $response->getStatusCode()->willReturn(400);
-        $response->getHeader('Cache-Control')->willReturn(array());
-        $response->getHeader('Expires')->willReturn(array());
+        $response->getHeader('Cache-Control')->willReturn([]);
+        $response->getHeader('Expires')->willReturn([]);
 
         $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
@@ -129,10 +129,10 @@ class CachePluginSpec extends ObjectBehavior
         $request->getUri()->willReturn('/');
         $response->getStatusCode()->willReturn(200);
         $response->getBody()->willReturn($stream);
-        $response->getHeader('Cache-Control')->willReturn(array('max-age=40'));
-        $response->getHeader('Age')->willReturn(array('15'));
-        $response->getHeader('Expires')->willReturn(array());
-        $response->getHeader('ETag')->willReturn(array());
+        $response->getHeader('Cache-Control')->willReturn(['max-age=40']);
+        $response->getHeader('Age')->willReturn(['15']);
+        $response->getHeader('Expires')->willReturn([]);
+        $response->getHeader('ETag')->willReturn([]);
 
         $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
@@ -172,9 +172,9 @@ class CachePluginSpec extends ObjectBehavior
         $request->getUri()->willReturn('/');
         $response->getStatusCode()->willReturn(200);
         $response->getBody()->willReturn($stream);
-        $response->getHeader('Cache-Control')->willReturn(array());
-        $response->getHeader('Expires')->willReturn(array());
-        $response->getHeader('ETag')->willReturn(array('foo_etag'));
+        $response->getHeader('Cache-Control')->willReturn([]);
+        $response->getHeader('Expires')->willReturn([]);
+        $response->getHeader('ETag')->willReturn(['foo_etag']);
 
         $pool->getItem('d20f64acc6e70b6079845f2fe357732929550ae1')->shouldBeCalled()->willReturn($item);
         $item->isHit()->willReturn(false);
@@ -287,8 +287,8 @@ class CachePluginSpec extends ObjectBehavior
         $request->withHeader(Argument::any(), Argument::any())->willReturn($request);
 
         $response->getStatusCode()->willReturn(304);
-        $response->getHeader('Cache-Control')->willReturn(array());
-        $response->getHeader('Expires')->willReturn(array())->shouldBeCalled();
+        $response->getHeader('Cache-Control')->willReturn([]);
+        $response->getHeader('Expires')->willReturn([])->shouldBeCalled();
 
         // Make sure we add back the body
         $response->withBody($stream)->willReturn($response)->shouldBeCalled();

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -187,7 +187,7 @@ final class CachePlugin implements Plugin
         }
         if ($this->getCacheControlDirective($response, 'no-store') ||
             $this->getCacheControlDirective($response, 'private')) {
-                return false;
+            return false;
         }
 
         return true;

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -185,8 +185,9 @@ final class CachePlugin implements Plugin
         if (!$this->config['respect_cache_headers']) {
             return true;
         }
-        if ($this->getCacheControlDirective($response, 'no-store') || $this->getCacheControlDirective($response, 'private')) {
-            return false;
+        if ($this->getCacheControlDirective($response, 'no-store') ||
+            $this->getCacheControlDirective($response, 'private')) {
+                return false;
         }
 
         return true;
@@ -205,7 +206,6 @@ final class CachePlugin implements Plugin
         $headers = $response->getHeader('Cache-Control');
         foreach ($headers as $header) {
             if (preg_match(sprintf('|%s=?([0-9]+)?|i', $name), $header, $matches)) {
-
                 // return the value for $name if it exists
                 if (isset($matches[1])) {
                     return $matches[1];


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in #24
| License         | MIT


#### What's in this PR?

Makes code PSR-2 compliant with the exception of relaxing the `PSR1.Methods.CamelCapsMethodName` for spec files. Additionally uses short array syntax in tests as discussed in #24. Lastly adds PHPCS to vendor and enables running it via `$ composer phpcs`.

I know this is three things in one PR but I feel these are closely related and the last one is easy remove if it is unwanted.

