### PR TITLE
Do not allow slash in method name

### DIFF
--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -347,6 +347,7 @@ final class CachePlugin implements Plugin
         $resolver->setAllowedValues('methods', function ($value) {
             /* RFC7230 sections 3.1.1 and 3.2.6 except limited to uppercase characters. */
             $matches = preg_grep('/[^A-Z0-9!#$%&\'*+\-.^_`|~]/', $value);
+
             return empty($matches);
         });
 

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -346,8 +346,7 @@ final class CachePlugin implements Plugin
         $resolver->setAllowedValues('hash_algo', hash_algos());
         $resolver->setAllowedValues('methods', function ($value) {
             /* RFC7230 sections 3.1.1 and 3.2.6 except limited to uppercase characters. */
-            $matches = preg_grep('/[^A-Z0-9!#$%&\'*\/+\-.^_`|~]/', $value);
-
+            $matches = preg_grep('/[^A-Z0-9!#$%&\'*+\-.^_`|~]/', $value);
             return empty($matches);
         });
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

#### What's in this PR?

Removes `/` character from regexp which is not allowed by the spec. It was bad copy paster from the RFC.

