### PR TITLE
The etag from data can never be a string

### DIFF
--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -435,10 +435,6 @@ final class CachePlugin implements Plugin
             return;
         }
 
-        if (!is_array($data['etag'])) {
-            return $data['etag'];
-        }
-
         foreach ($data['etag'] as $etag) {
             if (!empty($etag)) {
                 return $etag;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | maybe?
| Deprecations?   | no
| License         | MIT

I don't think this key can ever produce anything other than a string, since it is set by `$response->getHeader('ETag')` which is always of type `string[]`.

Is this there for historical reasons perhaps? If so, instead of this PR, a comment should be added, similar to to the isset removal comment.