### PR TITLE
Added blacklisted_paths option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 1.6.1 - 2019-11-25
+## 1.7.0 - unreleased
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.6.1 - 2019-11-25
+
+### Added
+
+* Added `blacklisted_paths` option, which takes an array of `strings` (regular expressions) and allows to define paths, that shall not be cached in any case.
+
 ## 1.6.0 - 2019-01-23
 
 ### Added

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -274,7 +274,7 @@ final class CachePlugin implements Plugin
     protected function isCacheableRequest(RequestInterface $request)
     {
         foreach ($this->config['blacklisted_paths'] as $not_to_cache_path) {
-            if (1 === preg_match('/'.$not_to_cache_path.'/', $request->getRequestTarget())) {
+            if (1 === preg_match('/'.$not_to_cache_path.'/', $request->getUri())) {
                 return false;
             }
         }

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -76,7 +76,6 @@ final class CachePlugin implements Plugin
             throw new \InvalidArgumentException('You can\'t provide config option "respect_cache_headers" and "respect_response_cache_directives". '.'Use "respect_response_cache_directives" instead.');
         }
 
-
         $optionsResolver = new OptionsResolver();
         $this->configureOptions($optionsResolver);
         $this->config = $optionsResolver->resolve($config);

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -247,7 +247,7 @@ final class CachePlugin implements Plugin
     /**
      * Verify that we can cache this response.
      *
-     * @param RequestInterface $request
+     * @param RequestInterface  $request
      * @param ResponseInterface $response
      *
      * @return bool

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -267,7 +267,7 @@ final class CachePlugin implements Plugin
     /**
      * Verify that we can cache this request.
      *
-     * @param RequestInterface  $request
+     * @param RequestInterface $request
      *
      * @return bool
      */

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -60,7 +60,7 @@ final class CachePlugin implements Plugin
      *              we have to store the cache for a longer time than the server originally says it is valid for.
      *              We store a cache item for $cache_lifetime + max age of the response.
      *     @var array $methods list of request methods which can be cached
-     *     @var array $blacklisted_paths list of regex patterns of paths explicitly not to be cached.
+     *     @var array $blacklisted_paths list of regex patterns of paths explicitly not to be cached
      *     @var array $respect_response_cache_directives list of cache directives this plugin will respect while caching responses
      *     @var CacheKeyGenerator $cache_key_generator an object to generate the cache key. Defaults to a new instance of SimpleGenerator
      *     @var CacheListener[] $cache_listeners an array of objects to act on the response based on the results of the cache check.
@@ -73,11 +73,9 @@ final class CachePlugin implements Plugin
         $this->streamFactory = $streamFactory;
 
         if (isset($config['respect_cache_headers']) && isset($config['respect_response_cache_directives'])) {
-            throw new \InvalidArgumentException(
-                'You can\'t provide config option "respect_cache_headers" and "respect_response_cache_directives". '.
-                'Use "respect_response_cache_directives" instead.'
-            );
+            throw new \InvalidArgumentException('You can\'t provide config option "respect_cache_headers" and "respect_response_cache_directives". '.'Use "respect_response_cache_directives" instead.');
         }
+
 
         $optionsResolver = new OptionsResolver();
         $this->configureOptions($optionsResolver);

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -60,6 +60,7 @@ final class CachePlugin implements Plugin
      *              we have to store the cache for a longer time than the server originally says it is valid for.
      *              We store a cache item for $cache_lifetime + max age of the response.
      *     @var array $methods list of request methods which can be cached
+     *     @var array $blacklisted_paths list of regex patterns of paths explicitly not to be cached.
      *     @var array $respect_response_cache_directives list of cache directives this plugin will respect while caching responses
      *     @var CacheKeyGenerator $cache_key_generator an object to generate the cache key. Defaults to a new instance of SimpleGenerator
      *     @var CacheListener[] $cache_listeners an array of objects to act on the response based on the results of the cache check.
@@ -183,7 +184,7 @@ final class CachePlugin implements Plugin
                 return $this->handleCacheListeners($request, $this->createResponseFromCacheItem($cacheItem), true, $cacheItem);
             }
 
-            if ($this->isCacheable($response)) {
+            if ($this->isCacheable($request, $response)) {
                 $bodyStream = $response->getBody();
                 $body = $bodyStream->__toString();
                 if ($bodyStream->isSeekable()) {
@@ -246,14 +247,21 @@ final class CachePlugin implements Plugin
     /**
      * Verify that we can cache this response.
      *
+     * @param RequestInterface $request
      * @param ResponseInterface $response
      *
      * @return bool
      */
-    protected function isCacheable(ResponseInterface $response)
+    protected function isCacheable(RequestInterface $request, ResponseInterface $response)
     {
         if (!in_array($response->getStatusCode(), [200, 203, 300, 301, 302, 404, 410])) {
             return false;
+        }
+
+        foreach ($this->config['blacklisted_paths'] as $not_to_cache_path) {
+            if (1 === preg_match('/'.$not_to_cache_path.'/', $request->getRequestTarget())) {
+                return false;
+            }
         }
 
         $nocacheDirectives = array_intersect($this->config['respect_response_cache_directives'], $this->noCacheFlags);
@@ -353,6 +361,7 @@ final class CachePlugin implements Plugin
             'respect_response_cache_directives' => ['no-cache', 'private', 'max-age', 'no-store'],
             'cache_key_generator' => null,
             'cache_listeners' => [],
+            'blacklisted_paths' => [],  // restricted for
         ]);
 
         $resolver->setAllowedTypes('cache_lifetime', ['int', 'null']);
@@ -360,6 +369,7 @@ final class CachePlugin implements Plugin
         $resolver->setAllowedTypes('respect_cache_headers', ['bool', 'null']);
         $resolver->setAllowedTypes('methods', 'array');
         $resolver->setAllowedTypes('cache_key_generator', ['null', 'Http\Client\Common\Plugin\Cache\Generator\CacheKeyGenerator']);
+        $resolver->setAllowedTypes('blacklisted_paths', 'array');
         $resolver->setAllowedValues('hash_algo', hash_algos());
         $resolver->setAllowedValues('methods', function ($value) {
             /* RFC7230 sections 3.1.1 and 3.2.6 except limited to uppercase characters. */

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -73,7 +73,7 @@ final class CachePlugin implements Plugin
         $this->streamFactory = $streamFactory;
 
         if (isset($config['respect_cache_headers']) && isset($config['respect_response_cache_directives'])) {
-            throw new \InvalidArgumentException('You can\'t provide config option "respect_cache_headers" and "respect_response_cache_directives". '.'Use "respect_response_cache_directives" instead.');
+            throw new \InvalidArgumentException('You can\'t provide config option "respect_cache_headers" and "respect_response_cache_directives". Use "respect_response_cache_directives" instead.');
         }
 
         $optionsResolver = new OptionsResolver();
@@ -271,7 +271,7 @@ final class CachePlugin implements Plugin
      *
      * @return bool
      */
-    protected function isCacheableRequest(RequestInterface $request)
+    private function isCacheableRequest(RequestInterface $request)
     {
         foreach ($this->config['blacklisted_paths'] as $not_to_cache_path) {
             if (1 === preg_match('/'.$not_to_cache_path.'/', $request->getUri())) {


### PR DESCRIPTION
 - adds a list of strings (regular expressions) to describe patterns of paths not to be cached.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Added an option 'blacklisted_paths'; a list of regular expressions to describe paths not to be cached. 


#### Why?

This is necessary if a third party resource is requested of providers, who don't get the usage of response cache headers. (But will return no-cache every time, for every endpoint)  


#### Example Usage

``` php
$cachePlugin = new CachePlugin($pool, $streamFactory, ['blacklisted_paths' => [
  '^\/this-path-shall\/not-been-cached\/.*',
]]);
```


#### Checklist

- [X] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [X] Documentation pull request created: https://github.com/php-http/documentation/pull/274

