### PR TITLE
Bugfix - matching blacklisted_paths on request_target instead of uri.

### DIFF
--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -274,7 +274,7 @@ final class CachePlugin implements Plugin
     private function isCacheableRequest(RequestInterface $request)
     {
         foreach ($this->config['blacklisted_paths'] as $not_to_cache_path) {
-            if (1 === preg_match('/'.$not_to_cache_path.'/', $request->getUri())) {
+            if (1 === preg_match('/'.$not_to_cache_path.'/', $request->getRequestTarget())) {
                 return false;
             }
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

matched the wrong subject; need to match the path of a request, not the uri object


#### Why?

need to match the path of a request, not the uri object

