### PR TITLE
[Compatibility] Support psr/cache 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "php-http/client-common": "^1.9 || ^2.0",
         "php-http/message-factory": "^1.0",
         "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0 || ^5.0"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #69 
| License         | MIT


#### What's in this PR?

Adds support for `psr/cache` 2.0. See #69
