### PR TITLE
Added psr/cache:^3.0 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "psr/cache": "^1.0 || ^2.0",
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "php-http/client-common": "^1.9 || ^2.0",
         "php-http/message-factory": "^1.0",
         "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0 || ^5.0 || ^6.0"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| Documentation   | N/A
| License         | MIT


#### What's in this PR?

Allow the usage of `psr/cache:3.0`.

#### Why?
Version `psr/cache:3.0` is already released a while ago and should be compatible with this plugin but the current composer.json configuration doesn't allow you to use this.
In my use case composer complains about a conflict while installing the cache-plugin because `symfony/cache:6.0` requires `psr/cache:3.0`.
