### PR TITLE
explicitly use 0 instead of adding null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Test with PHP 8.1 and 8.2
 - Made phpspec tests compatible with PSR-7 2.0 strict typing
+- Detect `null` and use 0 explicitly to calculate expiration
 
 ## 1.7.5 - 2022-01-18
 

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -58,7 +58,7 @@ final class CachePlugin implements Plugin
      *     bool respect_cache_headers: Whether to look at the cache directives or ignore them
      *     int default_ttl: (seconds) If we do not respect cache headers or can't calculate a good ttl, use this value
      *     string hash_algo: The hashing algorithm to use when generating cache keys
-     *     int cache_lifetime: (seconds) To support serving a previous stale response when the server answers 304
+     *     int|null cache_lifetime: (seconds) To support serving a previous stale response when the server answers 304
      *              we have to store the cache for a longer time than the server originally says it is valid for.
      *              We store a cache item for $cache_lifetime + max age of the response.
      *     string[] methods: list of request methods which can be cached
@@ -230,7 +230,7 @@ final class CachePlugin implements Plugin
             return null;
         }
 
-        return $this->config['cache_lifetime'] + $maxAge;
+        return ($this->config['cache_lifetime'] ?: 0) + ($maxAge ?: 0);
     }
 
     /**
@@ -368,7 +368,7 @@ final class CachePlugin implements Plugin
         $resolver->setAllowedTypes('default_ttl', ['int', 'null']);
         $resolver->setAllowedTypes('respect_cache_headers', ['bool', 'null']);
         $resolver->setAllowedTypes('methods', 'array');
-        $resolver->setAllowedTypes('cache_key_generator', ['null', 'Http\Client\Common\Plugin\Cache\Generator\CacheKeyGenerator']);
+        $resolver->setAllowedTypes('cache_key_generator', ['null', CacheKeyGenerator::class]);
         $resolver->setAllowedTypes('blacklisted_paths', 'array');
         $resolver->setAllowedValues('hash_algo', hash_algos());
         $resolver->setAllowedValues('methods', function ($value) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | discovered during https://github.com/php-http/HttplugBundle/pull/417
| Documentation   | -
| License         | MIT


#### What's in this PR?

Convert `null` to `0` before adding values to be cleaner.


#### Why?

Do not rely on implicit type conversions.

