### PR TITLE
upgrade phpspec to return correct types from test doubles

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: PHPStan
         uses: docker://oskarstark/phpstan-ga

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -25,15 +25,8 @@ jobs:
           tools: composer:v2
           coverage: none
 
-      - name: Install PHP 7 dependencies
+      - name: Install PHP dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
-        if: "matrix.php != '8.0'"
-
-      - name: Install PHP 8 dependencies
-        run: |
-          composer require "phpdocumentor/reflection-docblock:^5.2@dev" --no-interaction --no-update
-          composer update --prefer-dist --prefer-stable --no-interaction --no-progress --ignore-platform-req=php
-        if: "matrix.php == '8.0'"
 
       - name: Execute tests
         run: composer test
@@ -43,11 +36,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4']
+        php: ['7.1', '7.4', '8.0']
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -70,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.7.6 - 2023-04-23
+
+- Test with PHP 8.1 and 8.2
+- Made phpspec tests compatible with PSR-7 2.0 strict typing
+
 ## 1.7.5 - 2022-01-18
 
 - Allow installation with psr/cache 3.0 (1.0 and 2.0 are still allowed too)

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
-        "phpspec/phpspec": "^5.1 || ^6.0"
+        "phpspec/phpspec": "^5.1 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/spec/Cache/Generator/HeaderCacheKeyGeneratorSpec.php
+++ b/spec/Cache/Generator/HeaderCacheKeyGeneratorSpec.php
@@ -5,6 +5,9 @@ namespace spec\Http\Client\Common\Plugin\Cache\Generator;
 use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
+use Http\Client\Common\Plugin\Cache\Generator\HeaderCacheKeyGenerator;
+use Http\Client\Common\Plugin\Cache\Generator\CacheKeyGenerator;
+use Psr\Http\Message\UriInterface;
 
 class HeaderCacheKeyGeneratorSpec extends ObjectBehavior
 {
@@ -15,18 +18,20 @@ class HeaderCacheKeyGeneratorSpec extends ObjectBehavior
 
     public function it_is_initializable()
     {
-        $this->shouldHaveType('Http\Client\Common\Plugin\Cache\Generator\HeaderCacheKeyGenerator');
+        $this->shouldHaveType(HeaderCacheKeyGenerator::class);
     }
 
     public function it_is_a_key_generator()
     {
-        $this->shouldImplement('Http\Client\Common\Plugin\Cache\Generator\CacheKeyGenerator');
+        $this->shouldImplement(CacheKeyGenerator::class);
     }
 
-    public function it_generates_cache_from_request(RequestInterface $request, StreamInterface $body)
+    public function it_generates_cache_from_request(RequestInterface $request, UriInterface $uri, StreamInterface $body)
     {
+        $uri->__toString()->shouldBeCalled()->willReturn('http://example.com/foo');
+
         $request->getMethod()->shouldBeCalled()->willReturn('GET');
-        $request->getUri()->shouldBeCalled()->willReturn('http://example.com/foo');
+        $request->getUri()->shouldBeCalled()->willReturn($uri);
         $request->getHeaderLine('Authorization')->shouldBeCalled()->willReturn('bar');
         $request->getHeaderLine('Content-Type')->shouldBeCalled()->willReturn('application/baz');
         $request->getBody()->shouldBeCalled()->willReturn($body);

--- a/spec/Cache/Generator/SimpleGeneratorSpec.php
+++ b/spec/Cache/Generator/SimpleGeneratorSpec.php
@@ -4,33 +4,41 @@ namespace spec\Http\Client\Common\Plugin\Cache\Generator;
 
 use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
+use Http\Client\Common\Plugin\Cache\Generator\CacheKeyGenerator;
+use Http\Client\Common\Plugin\Cache\Generator\SimpleGenerator;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 
 class SimpleGeneratorSpec extends ObjectBehavior
 {
     public function it_is_initializable()
     {
-        $this->shouldHaveType('Http\Client\Common\Plugin\Cache\Generator\SimpleGenerator');
+        $this->shouldHaveType(SimpleGenerator::class);
     }
 
     public function it_is_a_key_generator()
     {
-        $this->shouldImplement('Http\Client\Common\Plugin\Cache\Generator\CacheKeyGenerator');
+        $this->shouldImplement(CacheKeyGenerator::class);
     }
 
-    public function it_generates_cache_from_request(RequestInterface $request)
+    public function it_generates_cache_from_request(RequestInterface $request, UriInterface $uri, StreamInterface $body)
     {
+        $uri->__toString()->shouldBeCalled()->willReturn('http://example.com/foo');
+        $body->__toString()->shouldBeCalled()->willReturn('bar');
         $request->getMethod()->shouldBeCalled()->willReturn('GET');
-        $request->getUri()->shouldBeCalled()->willReturn('http://example.com/foo');
-        $request->getBody()->shouldBeCalled()->willReturn('bar');
+        $request->getUri()->shouldBeCalled()->willReturn($uri);
+        $request->getBody()->shouldBeCalled()->willReturn($body);
 
         $this->generate($request)->shouldReturn('GET http://example.com/foo bar');
     }
 
-    public function it_generates_cache_from_request_with_no_body(RequestInterface $request)
+    public function it_generates_cache_from_request_with_no_body(RequestInterface $request, UriInterface $uri, StreamInterface $body)
     {
+        $uri->__toString()->shouldBeCalled()->willReturn('http://example.com/foo');
+        $body->__toString()->shouldBeCalled()->willReturn('');
         $request->getMethod()->shouldBeCalled()->willReturn('GET');
-        $request->getUri()->shouldBeCalled()->willReturn('http://example.com/foo');
-        $request->getBody()->shouldBeCalled()->willReturn('');
+        $request->getUri()->shouldBeCalled()->willReturn($uri);
+        $request->getBody()->shouldBeCalled()->willReturn($body);
 
         // No extra space after uri
         $this->generate($request)->shouldReturn('GET http://example.com/foo');


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

PSR-7 added return types in version 2, revealing that our test doubles returned wrong types in many places..

