### PR TITLE
Psr17: prevet usage of deprecated StreamFactory and use StreamFactoryInterface instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+# Version 2
+
+## 2.0.0 - XXXX-XX-XX
+
+### Changed
+- Drop support for using `StreamFactory`, only PSR-17 `StreamFactoryInterface` is now supported.
+
 # Version 1
 
 ## 1.8.0 - 2023-04-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 # Version 2
 
-## 2.0.0 - XXXX-XX-XX
+## 2.0.0 - (unreleased)
 
 ### Changed
-- Drop support for using `StreamFactory`, only PSR-17 `StreamFactoryInterface` is now supported.
+- Drop support of deprecated PHP-HTTP `StreamFactory`, only PSR-17 `StreamFactoryInterface` is now supported.
 
 # Version 1
 

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,12 @@
         "php": "^7.1 || ^8.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "php-http/client-common": "^1.9 || ^2.0",
-        "php-http/message-factory": "^1.0",
+        "psr/http-factory-implementation": "^1.0",
         "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
-        "phpspec/phpspec": "^5.1 || ^6.0 || ^7.0"
+        "phpspec/phpspec": "^5.1 || ^6.0 || ^7.0",
+        "nyholm/psr7": "^1.6.1"
     },
     "autoload": {
         "psr-4": {

--- a/spec/CachePluginSpec.php
+++ b/spec/CachePluginSpec.php
@@ -5,13 +5,13 @@ namespace spec\Http\Client\Common\Plugin;
 use Http\Client\Common\Plugin\Cache\Generator\SimpleGenerator;
 use PhpSpec\Wrapper\Collaborator;
 use Prophecy\Argument;
-use Http\Message\StreamFactory;
 use Http\Promise\FulfilledPromise;
 use PhpSpec\ObjectBehavior;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 use Http\Client\Common\Plugin\CachePlugin;
@@ -20,11 +20,11 @@ use Http\Client\Common\Plugin;
 class CachePluginSpec extends ObjectBehavior
 {
     /**
-     * @var StreamFactory&Collaborator
+     * @var StreamFactoryInterface&Collaborator
      */
     private $streamFactory;
 
-    function let(CacheItemPoolInterface $pool, StreamFactory $streamFactory)
+    function let(CacheItemPoolInterface $pool, StreamFactoryInterface $streamFactory)
     {
         $this->streamFactory = $streamFactory;
         $this->beConstructedWith($pool, $streamFactory, [
@@ -126,7 +126,7 @@ class CachePluginSpec extends ObjectBehavior
         RequestInterface $request,
         UriInterface $uri,
         ResponseInterface $response,
-        StreamFactory $streamFactory,
+        StreamFactoryInterface $streamFactory,
         StreamInterface $stream
     ) {
         $this->beConstructedWith($pool, $streamFactory, [
@@ -181,7 +181,7 @@ class CachePluginSpec extends ObjectBehavior
         CacheItemInterface $item,
         RequestInterface $request,
         ResponseInterface $response,
-        StreamFactory $streamFactory,
+        StreamFactoryInterface $streamFactory,
         StreamInterface $stream
     ) {
         $this
@@ -312,7 +312,7 @@ class CachePluginSpec extends ObjectBehavior
         $this->handleRequest($request, $next, function () {});
     }
 
-    function it_serves_a_cached_response(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, UriInterface $uri, StreamInterface $requestBody, ResponseInterface $response, StreamInterface $stream, StreamFactory $streamFactory)
+    function it_serves_a_cached_response(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, UriInterface $uri, StreamInterface $requestBody, ResponseInterface $response, StreamInterface $stream, StreamFactoryInterface $streamFactory)
     {
         $httpBody = 'body';
 
@@ -343,7 +343,7 @@ class CachePluginSpec extends ObjectBehavior
         $this->handleRequest($request, $next, function () {});
     }
 
-    function it_serves_and_resaved_expired_response(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, UriInterface $uri, StreamInterface $requestStream, ResponseInterface $response, StreamInterface $stream, StreamFactory $streamFactory)
+    function it_serves_and_resaved_expired_response(CacheItemPoolInterface $pool, CacheItemInterface $item, RequestInterface $request, UriInterface $uri, StreamInterface $requestStream, ResponseInterface $response, StreamInterface $stream, StreamFactoryInterface $streamFactory)
     {
         $httpBody = 'body';
 
@@ -398,7 +398,7 @@ class CachePluginSpec extends ObjectBehavior
         RequestInterface $request,
         UriInterface $uri,
         ResponseInterface $response,
-        StreamFactory $streamFactory,
+        StreamFactoryInterface $streamFactory,
         StreamInterface $stream
     ) {
         $this->beConstructedThrough('clientCache', [$pool, $streamFactory, [
@@ -452,7 +452,7 @@ class CachePluginSpec extends ObjectBehavior
         RequestInterface $request,
         UriInterface $uri,
         ResponseInterface $response,
-        StreamFactory $streamFactory,
+        StreamFactoryInterface $streamFactory,
         StreamInterface $stream
     ) {
         $this->beConstructedThrough('clientCache', [$pool, $streamFactory, [
@@ -498,7 +498,7 @@ class CachePluginSpec extends ObjectBehavior
         RequestInterface $request,
         UriInterface $uri,
         ResponseInterface $response,
-        StreamFactory $streamFactory,
+        StreamFactoryInterface $streamFactory,
         StreamInterface $stream
     ) {
         $this->beConstructedThrough('clientCache', [$pool, $streamFactory, [
@@ -550,7 +550,7 @@ class CachePluginSpec extends ObjectBehavior
     function it_can_be_initialized_with_custom_cache_key_generator(
         CacheItemPoolInterface $pool,
         CacheItemInterface $item,
-        StreamFactory $streamFactory,
+        StreamFactoryInterface $streamFactory,
         RequestInterface $request,
         UriInterface $uri,
         ResponseInterface $response,

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -6,8 +6,6 @@ use Http\Client\Common\Plugin;
 use Http\Client\Common\Plugin\Exception\RewindStreamException;
 use Http\Client\Common\Plugin\Cache\Generator\CacheKeyGenerator;
 use Http\Client\Common\Plugin\Cache\Generator\SimpleGenerator;
-use Http\Client\Common\Plugin\Cache\Listener\CacheListener;
-use Http\Message\StreamFactory;
 use Http\Promise\FulfilledPromise;
 use Http\Promise\Promise;
 use Psr\Cache\CacheItemInterface;
@@ -35,7 +33,7 @@ final class CachePlugin implements Plugin
     private $pool;
 
     /**
-     * @var StreamFactory|StreamFactoryInterface
+     * @var StreamFactoryInterface
      */
     private $streamFactory;
 
@@ -52,8 +50,7 @@ final class CachePlugin implements Plugin
     private $noCacheFlags = ['no-cache', 'private', 'no-store'];
 
     /**
-     * @param StreamFactory|StreamFactoryInterface $streamFactory
-     * @param mixed[]                              $config
+     * @param mixed[] $config
      *
      *     bool respect_cache_headers: Whether to look at the cache directives or ignore them
      *     int default_ttl: (seconds) If we do not respect cache headers or can't calculate a good ttl, use this value
@@ -69,12 +66,8 @@ final class CachePlugin implements Plugin
      *              Defaults to an empty array
      * }
      */
-    public function __construct(CacheItemPoolInterface $pool, $streamFactory, array $config = [])
+    public function __construct(CacheItemPoolInterface $pool, StreamFactoryInterface $streamFactory, array $config = [])
     {
-        if (!($streamFactory instanceof StreamFactory) && !($streamFactory instanceof StreamFactoryInterface)) {
-            throw new \TypeError(\sprintf('Argument 2 passed to %s::__construct() must be of type %s|%s, %s given.', self::class, StreamFactory::class, StreamFactoryInterface::class, \is_object($streamFactory) ? \get_class($streamFactory) : \gettype($streamFactory)));
-        }
-
         $this->pool = $pool;
         $this->streamFactory = $streamFactory;
 
@@ -95,12 +88,11 @@ final class CachePlugin implements Plugin
      * This method will setup the cachePlugin in client cache mode. When using the client cache mode the plugin will
      * cache responses with `private` cache directive.
      *
-     * @param StreamFactory|StreamFactoryInterface $streamFactory
-     * @param mixed[]                              $config        For all possible config options see the constructor docs
+     * @param mixed[] $config For all possible config options see the constructor docs
      *
      * @return CachePlugin
      */
-    public static function clientCache(CacheItemPoolInterface $pool, $streamFactory, array $config = [])
+    public static function clientCache(CacheItemPoolInterface $pool, StreamFactoryInterface $streamFactory, array $config = [])
     {
         // Allow caching of private requests
         if (\array_key_exists('respect_response_cache_directives', $config)) {
@@ -118,12 +110,11 @@ final class CachePlugin implements Plugin
      * This method will setup the cachePlugin in server cache mode. This is the default caching behavior it refuses to
      * cache responses with the `private`or `no-cache` directives.
      *
-     * @param StreamFactory|StreamFactoryInterface $streamFactory
-     * @param mixed[]                              $config        For all possible config options see the constructor docs
+     * @param mixed[] $config For all possible config options see the constructor docs
      *
      * @return CachePlugin
      */
-    public static function serverCache(CacheItemPoolInterface $pool, $streamFactory, array $config = [])
+    public static function serverCache(CacheItemPoolInterface $pool, StreamFactoryInterface $streamFactory, array $config = [])
     {
         return new self($pool, $streamFactory, $config);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | yes
| Related tickets | fixes https://github.com/php-http/cache-plugin/issues/85, finishes https://github.com/php-http/cache-plugin/pull/86
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

Finishes PR https://github.com/php-http/cache-plugin/issues/86


#### Why?

Avoids installing the deprecated package `php-http/message-factory`



#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

