### PR TITLE
fix #91: Change clientCache so it doesn't force no-cache & max-age response directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+# Version 3
+
+## 3.0.0 - 2025-XX-XX
+
+### Changed
+ - `clientCache()` will no longer force no-cache & max-age directives to be respected even when `respect_response_cache_directives` is set.
+
 # Version 2
 
 ## 2.0.1 - 2024-10-02

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -95,11 +95,7 @@ final class CachePlugin implements Plugin
     public static function clientCache(CacheItemPoolInterface $pool, StreamFactoryInterface $streamFactory, array $config = [])
     {
         // Allow caching of private requests
-        if (\array_key_exists('respect_response_cache_directives', $config)) {
-            $config['respect_response_cache_directives'][] = 'no-cache';
-            $config['respect_response_cache_directives'][] = 'max-age';
-            $config['respect_response_cache_directives'] = array_unique($config['respect_response_cache_directives']);
-        } else {
+        if (!\array_key_exists('respect_response_cache_directives', $config)) {
             $config['respect_response_cache_directives'] = ['no-cache', 'max-age'];
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | fixes #91
| License         | MIT


#### What's in this PR?

`clientCache()` will no longer force no-cache & max-age directives to be respected even when `respect_response_cache_directives` is set.